### PR TITLE
Upgrade RN

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "expo": "^20.0.0",
     "firebase": "^4.6.1",
     "immutable": "^3.8.2",
-    "react": "^16.0.0-alpha.12",
-    "react-native": "^0.47.0",
+    "react": "16.0.0",
+    "react-native": "0.50.3",
     "react-native-button": "^2.1.0",
     "react-native-pinch-zoom-view": "^0.1.2"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import MapScreen from './Components/MapScreen/MapScreen';
-import * as firebase from 'firebase';
+import firebase from 'firebase';
 
 // Initialize Firebase
 // Firebase Console for this project can be found at https://console.firebase.google.com/u/0/project/mobile-passport/overview


### PR DESCRIPTION
Upgrades our RN project, because my app was refusing to run due to some obscure error caused by the mismatch between our RN and React versions.
Also clears up the firebase import from my last PR.

Verification that the upgrade worked consisted of just running the app (and fixing up the index.js file in the react-native-pinch-zoom-view project, which was using the wrong kind of PropTypes import.  This has been fixed in their project, but not released).